### PR TITLE
gvim vs gvim.exe

### DIFF
--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -15,7 +15,7 @@ let g:startify_session_dir = resolve(expand(get(g:, 'startify_session_dir',
 augroup startify
   autocmd!
   autocmd VimEnter *
-        \ if !argc() && (line2byte('$') == -1) && (v:progname =~? 'vim' || v:progname =~? 'gvim') |
+        \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^vim' || v:progname =~? '^gvim') |
         \   call s:insane_in_the_membrane() |
         \ endif
 augroup END


### PR DESCRIPTION
It seems that under certain conditions on Windows systems `v:progname` contains `gvim.exe` instead of `gvim`. Same applies to `vim`, `evim`, etc. So, regexp expression instead of strict match seems legit.
