### PR TITLE
Optionally restore cursor position position

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -14,6 +14,7 @@ let s:numfiles     = get(g:, 'startify_files_number', 10)
 let s:show_special = get(g:, 'startify_enable_special', 1)
 let s:session_dir  = resolve(expand(get(g:, 'startify_session_dir',
       \ has('win32') ? '$HOME\vimfiles\session' : '~/.vim/session')))
+let s:restore_position = get(g:, 'startify_restore_position', 0)
 
 " Function: #insane_in_the_membrane {{{1
 function! startify#insane_in_the_membrane() abort
@@ -71,6 +72,9 @@ function! startify#insane_in_the_membrane() abort
   endif
 
   autocmd startify CursorMoved <buffer> call s:set_cursor()
+  if s:restore_position
+    autocmd startify BufReadPost * call s:restore_position()
+  endif
 
   1
   call cursor((s:show_special ? 4 : 2) + s:offset_header, 5)
@@ -409,6 +413,14 @@ function! s:get_index_as_string(idx) abort
     return (a:idx < listlen) ? g:startify_custom_indices[a:idx] : string(a:idx - listlen)
   else
     return string(a:idx)
+  endif
+endfunction
+
+" Function: s:restore_position {{{1
+function! s:restore_position()
+  autocmd! startify *
+  if line("'\"") > 0 && line("'\"") <= line('$')
+    call cursor(getpos("'\"")[1:])
   endif
 endfunction
 

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -237,6 +237,11 @@ Example:
                 \ '',
                 \ ]
 
+============-
+
+    let g:startify_restore_position = 0
+
+Jump to the previous cursor position of a file when opening it.
 
 ==============================================================================
 4. Commands                                                  *startify-commands*


### PR DESCRIPTION
This use the '" mark to restore the cursor position when opening a file,
implemented as BufReadPost autocmd.
