### PR TITLE
allow progname regex to match 'vimx'

### DIFF
--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -10,7 +10,7 @@ let g:loaded_startify = 1
 
 augroup startify
   autocmd VimEnter *
-        \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gm]\=vim\%[\.exe]$') |
+        \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gm]\=vimx\?\%[\.exe]$') |
         \   call startify#insane_in_the_membrane() |
         \ endif |
         \ autocmd! startify VimEnter


### PR DESCRIPTION
When launching `vimx` (the console version of vim that supports the X clipboard and mouse interactions), Startify does not launch automatically.  This patch fixes that.  Certainly open to other ideas, though!
