### PR TITLE
Set correct filetype

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -48,7 +48,7 @@ function! startify#insane_in_the_membrane() abort
 
   setlocal noswapfile nobuflisted buftype=nofile bufhidden=wipe
   setlocal nonumber nocursorline nolist statusline=\ startify
-  setfiletype startify
+  set filetype=startify
 
   if v:version >= 703
     setlocal norelativenumber


### PR DESCRIPTION
Filetype of startify buffer is empty on startup, which causes the startify buffer to be uncolored. Only the first startup is uncolored! :Startify<CR> has a correctly set filetype.
This change sets the filetype correctly even on the first startup, so it gets colored in any condition.
(Windows 7 32-bit, gvim 7.4)
