### PR TITLE
New options: g:startify_save{vars,cmds}

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -165,13 +165,17 @@ function! startify#session_save(...) abort
 
   let spath = s:session_dir . s:sep . sname
   if !filereadable(spath)
-    execute 'mksession '. fnameescape(spath) | echo 'Session saved under: '. spath
+    execute 'mksession '. fnameescape(spath)
+    call startify#session_save_more(fnameescape(spath))
+    echo 'Session saved under: '. spath
     return
   endif
 
   echo 'Session already exists. Overwrite?  [y/n]' | redraw
   if nr2char(getchar()) == 'y'
-    execute 'mksession! '. fnameescape(spath) | echo 'Session saved under: '. spath
+    execute 'mksession! '. fnameescape(spath)
+    call startify#session_save_more(fnameescape(spath))
+    echo 'Session saved under: '. spath
   else
     echo 'Did NOT save the session!'
   endif
@@ -202,6 +206,22 @@ function! startify#session_delete(...) abort
   else
     echo 'Deletion aborted!'
   endif
+endfunction
+
+" Function: #session_save_more {{{1
+function! startify#session_save_more(spath)
+  execute "split " . a:spath
+  for var in get(g:, 'startify_savevars', [])
+    if exists(var)
+      call append(line('$')-3, 'let '. var .'='. strtrans(string(eval(var))))
+    endif
+  endfor
+  for cmd in get(g:, 'startify_savecmds', [])
+    call append(line('$')-3, cmd)
+  endfor
+  w!
+  setlocal bufhidden=delete
+  silent! hide
 endfunction
 
 " Function: #session_list {{{1

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -93,6 +93,8 @@ default values.
     |g:startify_restore_position|
     |g:startify_empty_buffer_key|
     |g:startify_enable_special|
+    |g:startify_savevars|
+    |g:startify_savecmds|
 
 
 ============-                                           *g:startify_session_dir*
@@ -235,6 +237,33 @@ Default: does not exist
 
 Show <empty buffer> and <quit>.
 
+============-                                              *g:startify_savevars*
+
+    let g:startify_savevars = []
+
+Include a list of variables in here which you would like Startify to save into
+the session file in addition to what Vim normally saves into the session file.
+For example, Vim will not normally save all-lowercase global variables, which
+are common for plugin settings.  It may be advisable to include
+|g:startify_savevars| and |g:startify_savecmds| into this list so they are
+saved every time the session saves.
+
+Example: let g:startify_savevars = [
+           \ 'g:startify_savevars',
+           \ 'g:startify_savecmds',
+           \ 'g:random_plugin_use_feature']
+
+============-                                              *g:startify_savecmds*
+
+    let g:startify_savecmds = []
+
+Include a list of cmdline commands which Vim will run upon loading the
+session.  This can be useful to set various things (other than variables,
+|g:startify_savevars| above) which Vim may not normally save into the session
+file, as well as run external commands upon loading a session.
+
+Example: let g:startify_savecmds = [
+           \ 'silent !pdfreader ~/latexproject/main.pdf &']
 
 ============-                                      *g:startify_restore_position*
 


### PR DESCRIPTION
Added two variables to have Startify save additional information in the sessions:
- g:startify_savevars, which will save variables into the sessions that Vim won't do normally.
- g:startify_savecmds, which will save commands for Vim to run upon loading a session.
