### PR TITLE
Missing coma in #startify_skiplist (syntax error)

### DIFF
--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -242,7 +242,7 @@ Example:
 >
     let g:startify_skiplist = [
            \ '.vimgolf',
-           \ '^/tmp'
+           \ '^/tmp',
            \ '/project/.*/documentation'
            \ ]
 <


### PR DESCRIPTION
just syntax error
