### PR TITLE
setlocal nocursorcolumn

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -68,7 +68,7 @@ function! startify#insane_in_the_membrane() abort
   endif
 
   setlocal noswapfile nobuflisted buftype=nofile bufhidden=wipe
-  setlocal nonumber nocursorline nolist statusline=\ startify
+  setlocal nonumber nocursorline nocursorcolumn nolist statusline=\ startify
   set filetype=startify
 
   if v:version >= 703


### PR DESCRIPTION
As long as you're disabling `cursorline`, you should also disable `cursorcolumn`. I'm unaware of how popular the practice is, but having both set gives you "crosshairs" in a sense. Either way they're one in the same and both should be disabled :)
