### PR TITLE
Windows fixes

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -292,7 +292,7 @@ function! s:show_dir(cnt) abort
 
       let entries[fullpath] = 1
       let index = s:get_index_as_string(cnt)
-      let display_fname = s:relative_path ? fnamemodify(fname, ':.') : fname
+      let display_fname = s:relative_path ? fnamemodify(glob(fname), ':.') : fnamemodify(glob(fname), ':p:~')
 
       call append('$', '   ['. index .']'. repeat(' ', (3 - strlen(index))) . display_fname)
       execute 'nnoremap <buffer>' index ':edit' fnameescape(fname) '<bar> call <sid>check_user_options()<cr>'
@@ -338,7 +338,7 @@ function! s:show_files(cnt) abort
 
     let entries[fullpath] = 1
     let index = s:get_index_as_string(cnt)
-    let display_fname = s:relative_path ? fnamemodify(fname, ':.') : fname
+    let display_fname = s:relative_path ? fnamemodify(glob(fname), ':.') : fnamemodify(glob(fname), ':p:~')
 
     call append('$', '   ['. index .']'. repeat(' ', (3 - strlen(index))) . display_fname)
     execute 'nnoremap <buffer>' index ':edit' fnameescape(fname) '<bar> call <sid>check_user_options()<cr>'


### PR DESCRIPTION
As promised, here are the other Windows-related patches. They fix a few quirks and issues with pathname formatting and the _dir_ section not showing when it should

I tried to make the commit messages as helpful, however brief as possible, and on top of that, I have a handful of comparison screenshots to supplement.

**Before the patches, with** `noshellslash`: [[Link]](https://www.dropbox.com/s/o3jcd5kqy34n4ve/Startify_PRE-Patch_nossl.png)
Notice the mixed slashes and the improper file highlighting due to inconsistencies between `shellslash` and the displayed path. Also take note that the _dir_ section is not visible, despite being enabled.

**Before the patches, with** `shellslash`: [[Link]](https://www.dropbox.com/s/4odmzi53h2qhnj3/Startify_PRE-Patch_ssl.png)
Not much better, however the _dir_ section is actually visible.

And now for the nice part :)

**After the patches, with** `noshellslash` [[Link]](https://www.dropbox.com/s/n0mcje2j5tmttqz/Startify_POST-Patch_nossl.png)
No mixed slashes, no improper highlighting, and the _dir_ section is visible!

**After the patches, with** `shellslash` [[Link]](https://www.dropbox.com/s/5lhtog2mkjheen4/Startify_POST-Patch_ssl.png)
Same as before, but *nix styled thanks to `shellslash`.

While I tried to make the commit log speak for itself, if you'd like me to explain anything in detail, please do not hesitate to ask!
