### PR TITLE
Hopefully fix 'dir' section showing properly

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -370,7 +370,11 @@ function! s:sanitize_file_list(flist)
   for fname in a:flist
     " Force slashes to abide by 'shellslash' setting
     " glob() will also return nothing for invalid/non-existent files
-    let fname = glob(escape(fname, '[]'))
+    if has('win32') || has('win64')
+      let fname = glob(fname)
+    else
+      let fname = glob(escape(fname, '[]'))
+    endif
 
     if strlen(fname) == 0
       continue


### PR DESCRIPTION
glob(v:val) to make matching work correctly, which _hopefully_ covers all bases
now between shellslash and Windows/Linux variations...
