### PR TITLE
Qt Vim deserves some startup love too

### DIFF
--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -13,7 +13,7 @@ let g:loaded_startify = 1
 augroup startify
   if !get(g:, 'startify_disable_at_vimenter')
     autocmd VimEnter *
-          \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gm]\=vim\=x\=\%[\.exe]$') |
+          \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gmq]\=vim\=x\=\%[\.exe]$') |
           \   call startify#insane_in_the_membrane() |
           \ endif |
           \ autocmd! startify VimEnter


### PR DESCRIPTION
Insipired by Issue #79, I've added qvim to the matched names on startup. I wasn't even aware that this was the reason why my qvim didn't have startify working till you did that commit. :)
