### PR TITLE
Make startify work with Neovim

### DIFF
--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -13,7 +13,7 @@ let g:loaded_startify = 1
 augroup startify
   if !get(g:, 'startify_disable_at_vimenter')
     autocmd VimEnter *
-          \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gmq]\=vim\=x\=\%[\.exe]$') |
+          \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gmnq]\=vim\=x\=\%[\.exe]$') |
           \   call startify#insane_in_the_membrane() |
           \ endif |
           \ autocmd! startify VimEnter


### PR DESCRIPTION
I think tarruda settled on `nvim` as the binary name, at least for now.
