### PR TITLE
Add Makefile for `make test`, automatically setting up Vader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+test: test/vader.vim
+	cd test && ./run
+
+# Use existing vader install from ~/.vim, or clone it.
+test/vader.vim:
+	existing_vader=$(firstword $(wildcard ~/.vim/*bundle*/vader*)); \
+	if [ -n "$$existing_vader" ]; then \
+		( cd test && ln -s $$existing_vader vader.vim ); \
+	else \
+		git https://github.com/junegunn/vader.vim test/vader.vim; \
+	fi
+
+.PHONY: test


### PR DESCRIPTION
This could be also used for travis.

`testi` could be added for "interactive" tests, without `!` on `Vader`.
