### PR TITLE
close: only use `b#` if it's different from '%'

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -625,7 +625,7 @@ endfunction
 " Function: s:close {{{1
 function! s:close() abort
   if len(filter(range(0, bufnr('$')), 'buflisted(v:val)'))
-    if bufloaded(bufnr('#'))
+    if bufloaded(bufnr('#')) && bufnr('#') != bufnr('%')
       buffer #
     else
       bnext


### PR DESCRIPTION
I have noticed that `[q] quit` might silently do nothing, and it turned out that `#` was the current (startify) buffer.
