### PR TITLE
modified plugin/startify.vim and autoload/startify.vim

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -227,6 +227,16 @@ function! startify#session_save(...) abort
   endif
 endfunction
 
+" Function: #session_close {{{1
+function! startify#session_close()
+  if exists('v:this_session') && filewritable(v:this_session)
+    call startify#session_write(fnameescape(v:this_session))
+    let v:this_session=''
+  endif
+  call startify#session_delete_buffers()
+  Startify
+endfunction
+
 " Function: #session_write {{{1
 function! startify#session_write(spath)
   let ssop = &sessionoptions

--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -30,6 +30,7 @@ augroup END
 command! -nargs=? -bar -complete=customlist,startify#session_list SSave   call startify#session_save(<f-args>)
 command! -nargs=? -bar -complete=customlist,startify#session_list SLoad   call startify#session_load(<f-args>)
 command! -nargs=? -bar -complete=customlist,startify#session_list SDelete call startify#session_delete(<f-args>)
+command! -nargs=0 -bar SClose call startify#session_close()
 command! -nargs=0 -bar Startify call startify#insane_in_the_membrane()
 
 nnoremap <silent><plug>(startify-open-buffers) :<c-u>call startify#open_buffers()<cr>


### PR DESCRIPTION
First, let me say that I am a huge fan of startify.  It has immensely improved
my efficiency as a vim user.

There is however, one use case for which I am forever fighting.  When I am in a
session and I want to leave it to open another file, but not open another
session, I find myself having some odd occurrences when I then quit later the
session (because I have my sessions auto_saved).  I feel that a simple SClose
to save and close the current session is needed.  I have arranged it so that
Startify is automatically fired (otherwise the user could just :qall).

Thank you for your time.  I hope you like what I've done.

-John Shea