### PR TITLE
Use blackhole register when removing lines

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -268,7 +268,7 @@ function! startify#session_write(spath)
     " remove lines from the session file
     if exists('g:startify_session_remove_lines')
       for pattern in g:startify_session_remove_lines
-        execute 'silent global/'. pattern .'/delete'
+        execute 'silent global/'. pattern .'/delete_'
       endfor
     endif
 


### PR DESCRIPTION
During session save, when removing lines, we don't want to store the content in the unnamed register, takes more time and changes clipboard content. Just use the blackhole register.

Probably the smallest pull request ever :)