### PR TITLE
Allow customizing/overwriting the file entries display lines

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -16,6 +16,8 @@ let s:delete_buffers = get(g:, 'startify_session_delete_buffers')
 let s:relative_path  = get(g:, 'startify_relative_path') ? ':.' : ':p:~'
 let s:session_dir    = resolve(expand(get(g:, 'startify_session_dir',
       \ has('win32') ? '$HOME\vimfiles\session' : '~/.vim/session')))
+let s:file_entry_display  = get(g:, 'startify_custom_file_entry_display', 
+      \ "repeat(' ', (3 - strlen(index))) . entry_path")
 
 let s:skiplist = get(g:, 'startify_skiplist', [
       \ 'COMMIT_EDITMSG',
@@ -404,7 +406,7 @@ function! s:display_by_path(path_prefix, path_format) abort
 
     for [absolute_path, entry_path] in oldfiles
       let index = s:get_index_as_string(s:entry_number)
-      call append('$', '   ['. index .']'. repeat(' ', (3 - strlen(index))) . entry_path)
+      call append('$', '   ['. index .']' . eval(s:file_entry_display))
       if has('win32')
         let absolute_path = substitute(absolute_path, '\[', '\[[]', 'g')
       endif

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -93,6 +93,7 @@ default values.
     |g:startify_custom_footer|
     |g:startify_custom_header|
     |g:startify_custom_indices|
+    |g:startify_custom_file_entry_display|
     |g:startify_disable_at_vimenter|
     |g:startify_enable_special|
     |g:startify_enable_unsafe|
@@ -445,6 +446,33 @@ Also have a look at |startify-faq-08|.
     let g:startify_custom_footer = ''
 <
 Same as the custom header, but shown at the bottom of the startify buffer.
+
+------------------------------------------------------------------------------
+                                          *g:startify_custom_file_entry_display*
+>
+    let g:startify_custom_file_entry_display =
+            \ "repeat(' ', (3 - strlen(index))) . entry_path"
+<
+Use any list of strings as indices instead of increasing numbers. If there are
+more startify entries than actual items in the custom list, the remaining
+entries will be filled using the default numbering scheme starting from 0.
+
+Thus you can create your own indexing scheme that fits your keyboard layout.
+You don't want to leave the home row, do you?!
+
+Example:
+>
+    let g:startify_custom_file_entry_display =
+            \ "' >' . repeat(' ', (3 - strlen(index))) . entry_path"
+<
+This would result in:
+
+    [0] >  /most/recently/used/file1
+    [1] >  /most/recently/used/file2
+    [2] >  /most/recently/used/file3
+    etc.
+
+NOTE: There is no sanitizing going on, so you should know what you're doing!
 
 ------------------------------------------------------------------------------
                                                 *g:startify_disable_at_vimenter*


### PR DESCRIPTION
* adds optional customizable global variable
* updates documentation with the option and an example usage

created for: https://github.com/ryanoasis/vim-devicons/issues/94

my example use case:

```vim
let g:startify_custom_entry_display = "\" (\" . WebDevIconsGetFileTypeSymbol(entry_path) . \") \" . repeat(' ', (3 - strlen(index))) . entry_path"
```

![selection_19_08_15_19 45 59_813x645_001](https://cloud.githubusercontent.com/assets/8083459/9372633/da9a3fce-46ae-11e5-8374-276b7708ebbb.png)

* one thing I noticed was syntax highlight was a bit off but maybe that is okay? (would only affect those using vim-devicons or those making use of this new global)

Thanks!