### PR TITLE
resolve symlinks in MRU filter

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -19,7 +19,7 @@ let s:session_dir    = resolve(expand(get(g:, 'startify_session_dir',
 
 let s:skiplist = get(g:, 'startify_skiplist', [
       \ 'COMMIT_EDITMSG',
-      \ escape(fnamemodify($VIMRUNTIME, ':p'), '\') .'doc',
+      \ escape(resolve(fnamemodify($VIMRUNTIME, ':p')), '\') .'doc',
       \ 'bundle/.*/doc',
       \ ])
 


### PR DESCRIPTION
For example, OpenSUSE uses a `.../vim/current` symlink for `$VIMRUNTIME`. The skiplist now resolves these to filter them too.