### PR TITLE
Avoid 'Press Enter' message on session write

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -281,7 +281,7 @@ function! startify#session_write(spath)
   if exists('g:startify_session_remove_lines')
         \ || exists('g:startify_session_savevars')
         \ || exists('g:startify_session_savecmds')
-    execute 'split' a:spath
+    silent execute 'split' a:spath
 
     " remove lines from the session file
     if exists('g:startify_session_remove_lines')


### PR DESCRIPTION
Defining either of `g:startify_session_savevars` and `g:startify_session_savecmds` will cause 'Press Enter' on `:SSave`. This harmless PR fixes the issue.