### PR TITLE
Removed parentheses around devicons

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -440,7 +440,7 @@ function! s:display_by_path(path_prefix, path_format, use_env) abort
 
   let entry_format = "'   ['. index .']'. repeat(' ', (3 - strlen(index)))"
   if exists('*WebDevIconsGetFileTypeSymbol')  " support for vim-devicons
-    let entry_format .= ". '('. WebDevIconsGetFileTypeSymbol(entry_path) .') '. entry_path"
+    let entry_format .= ". WebDevIconsGetFileTypeSymbol(entry_path) .' '.  entry_path"
   else
     let entry_format .= '. entry_path'
   endif


### PR DESCRIPTION
Perhaps it's just me, but those parentheses look weird. I've removed them.
I think it looks better.

![screenshot from 2016-04-22 11-12-12](https://cloud.githubusercontent.com/assets/1187078/14737364/face7ad2-087b-11e6-8b25-ebe162ea3cee.png)
