### PR TITLE
Add ex command list

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -113,6 +113,7 @@ function! startify#insane_in_the_membrane() abort
         \ ['   MRU '. getcwd()], 'dir',
         \ ['   Sessions'],       'sessions',
         \ ['   Bookmarks'],      'bookmarks',
+        \ ['   Ex commands'],    'ex_commands',
         \ ])
 
   for item in s:lists
@@ -616,6 +617,33 @@ function! s:show_bookmarks() abort
     call s:register(line('$'), index, 'file', 'edit', path, s:nowait)
 
     unlet bookmark  " avoid type mismatch for heterogeneous lists
+  endfor
+
+  call append('$', '')
+endfunction
+
+" Function: s:show_ex_commands {{{1
+function! s:show_ex_commands() abort
+  if !exists('g:startify_ex_commands') || empty(g:startify_ex_commands)
+    return
+  endif
+
+  if exists('s:last_message')
+    call s:print_section_header()
+  endif
+
+  for ex_command_item in g:startify_ex_commands
+    if type(ex_command_item) == type({})
+      let [index, ex_command_str] = items(ex_command_item)[0]
+    else  " string
+      let [index, ex_command_str] = [s:get_index_as_string(s:entry_number), ex_command_item]
+      let s:entry_number += 1
+    endif
+
+    call append('$', '   ['. index .']'. repeat(' ', (3 - strlen(index))) . ex_command_str)
+    call s:register(line('$'), index, 'special', ex_command_str, '', s:nowait_string)
+
+    unlet ex_command_item  " avoid type mismatch for heterogeneous lists
   endfor
 
   call append('$', '')

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -36,8 +36,8 @@ CONTENTS                                                     *startify-contents*
 ==============================================================================
 INTRO                                                           *startify-intro*
 
-Startify is a plugin that shows recently used files, bookmarks and
-sessions that were saved to a certain directory.
+Startify is a plugin that shows recently used files, bookmarks, ex commands
+and sessions that were saved to a certain directory.
 
 ==============================================================================
 USAGE                                                           *startify-usage*
@@ -48,8 +48,8 @@ Startify basically provides two things:
    it reads from STDIN), startify will show a small but pretty start screen
    that shows recently used files (using viminfo) and sessions by default.
 
-   Additionally, you can define bookmarks, thus entries for files that always
-   should be available on the start screen.
+   Additionally, you can define bookmarks (thus entries for files) and ex
+   commands that always should be available on the start screen.
 
    You can either navigate to a certain menu entry and hit enter or you just
    key in whatever is written between the square brackets on that line. You
@@ -87,6 +87,7 @@ default values.
 
     Most used options:~
     |g:startify_bookmarks|
+    |g:startify_ex_commands|
     |g:startify_change_to_dir|
     |g:startify_change_to_vcs_root|
     |g:startify_custom_header|
@@ -128,7 +129,8 @@ The default for Windows systems is '$HOME\vimfiles\session'.
 ------------------------------------------------------------------------------
                                                          *g:startify_list_order*
 >
-    let g:startify_list_order = ['files', 'dir', 'bookmarks', 'sessions']
+    let g:startify_list_order = ['files', 'dir', 'bookmarks', 'sessions',
+        \ 'ex_commands']
 <
 At the moment startify supports these lists:~
 
@@ -150,6 +152,10 @@ At the moment startify supports these lists:~
 4) "sessions"
 
    This lists all the sessions saved in the directory |g:startify_session_dir|.
+
+5) "ex_commands"
+
+    This lists ex commands defined in |g:startify_ex_commands|.
 
 Section headers:~
 
@@ -174,6 +180,8 @@ Section headers example:~
             \ 'sessions',
             \ ['   These are my bookmarks:'],
             \ 'bookmarks',
+            \ ['   These are my ex commands:'],
+            \ 'ex_commands',
             \ ]
 <
 Feel free to add some cool ASCII action!
@@ -190,6 +198,22 @@ the value the path.
 Example:
 >
     let g:startify_bookmarks = [ {'c': '~/.vimrc'}, '~/.zshrc' ]
+<
+NOTE: Avoid using keys from |startify-mappings| if providing custom indices.
+
+------------------------------------------------------------------------------
+                                                        *g:startify_ex_commands*
+>
+    let g:startify_ex_commands = []
+<
+A list of ex commands (without the colon) to display on the start screen. The
+list can contain two kinds of types. Either an ex command or a dictionary
+whereas the key is the custom index and the value the ex command.
+
+Example:
+>
+    let g:startify_ex_commands = [ {'s': 'enew | set ft=sql'},
+        \ 'colorscheme bclear' ]
 <
 NOTE: Avoid using keys from |startify-mappings| if providing custom indices.
 
@@ -889,6 +913,8 @@ This is my configuration..
       \ 'sessions',
       \ ['   Bookmarks:'],
       \ 'bookmarks',
+      \ ['   Ex commands:'],
+      \ 'ex_commands',
       \ ]
 
     let g:startify_skiplist = [
@@ -901,6 +927,11 @@ This is my configuration..
     let g:startify_bookmarks = [
                 \ { 'c': '~/.vim/vimrc' },
                 \ '~/golfing',
+                \ ]
+
+    let g:startify_ex_commands = [
+                \ { 's': 'enew | set ft=sql' },
+                \ 'colorscheme bclear',
                 \ ]
 
     let g:startify_custom_footer =


### PR DESCRIPTION
Hi,

I'm not sure you'll think this is needed in the plugin, but I added the ability to have a list of ex commands on the start screen. They behave pretty much exactly like bookmarks, except that the list items are of type `special` instead of `file` and are thus executed when activated.

For example, I have a shell command I use all the time, `d4 new`, which creates a blank blog post, pre-populated with metadata like today's date, and opens it for editing. This I've found is nice to have on the start screen as `silent ! d4 new`.

Could perhaps also be useful in issue #215.