### PR TITLE
Disable colorcolumn in startify buffer

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -62,6 +62,7 @@ function! startify#insane_in_the_membrane() abort
         \ norelativenumber
         \ nospell
         \ noswapfile
+        \ colorcolumn=
   if empty(&statusline)
     setlocal statusline=\ startify
   endif


### PR DESCRIPTION
In a previous [issue][1] someone asked to disable colorcolumn, but it was
fixed with by disabling cursorcolumn in a [pull request][2].

Both should be disabled.

This change disables colorcolumn.

[1]: https://github.com/mhinz/vim-startify/issues/80
[2]: https://github.com/mhinz/vim-startify/pull/83