### PR TITLE
Revert df32cef commit to fix issue #252

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -11,7 +11,7 @@ let g:autoloaded_startify = 1
 
 " Init: values {{{1
 let s:nowait_string  = v:version >= 704 || (v:version == 703 && has('patch1261')) ? '<nowait>' : ''
-let s:nowait         = get(g:, 'startify_mapping_nowait', 1) ? s:nowait_string : ''
+let s:nowait         = get(g:, 'startify_mapping_nowait') ? s:nowait_string : ''
 let s:padding_left   = repeat(' ', get(g:, 'startify_padding_left', 3))
 let s:numfiles       = get(g:, 'startify_files_number', 10)
 let s:show_special   = get(g:, 'startify_enable_special', 1)

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -599,12 +599,16 @@ $PWD and $OLDPWD are ignored.
 -----------------------------------------------------------------------------
                                                     *g:startify_mapping_nowait*
 >
-    let g:startify_mapping_nowait = 1
+    let g:startify_mapping_nowait = 0
 <
 Force the usage of |<nowait>| in all mappings.
 
 This helps guarding against global mappings that start with the same
-characters as the Startify indexes.
+characters as a Startify index, but might break local mappings, e.g. when you
+have indexes "1" and "11", the "11" won't be accessable anymore, since "1"
+will be opened right way.
+
+Only use this when you know what you're doing.
 
 NOTE: This option needs at least Vim 7.3.1261. It gets ignored otherwise.
 


### PR DESCRIPTION
Revert "Enable g:startify_mapping_nowait by default"
This reverts commit df32cef08b4376ffcbf09f7b8e5bf1bfc2a0bf24.

startify_mapping_nowait = 1 makes impossible to use mappings above 10.
To cite the documentation deleted in the reverted commit:

"Only use this when you know what you're doing."

Such an option should not be enabled by default.