### PR TITLE
No ~/Startify file

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -153,6 +153,7 @@ function! startify#insane_in_the_membrane() abort
 
   silent! file Startify
   set filetype=startify
+  set readonly
   if exists('#User#Startified')
     if v:version > 703 || v:version == 703 && has('patch442')
       doautocmd <nomodeline> User Startified

--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -17,6 +17,8 @@ augroup startify
     autocmd VimLeave * call s:extinction()
   endif
 
+  autocmd VimLeave * call s:cleanhome()
+
   autocmd QuickFixCmdPre  *vimgrep* let g:startify_locked = 1
   autocmd QuickFixCmdPost *vimgrep* let g:startify_locked = 0
 augroup END
@@ -51,6 +53,12 @@ endfunction
 function! s:extinction()
   if exists('v:this_session') && filewritable(v:this_session)
     call startify#session_write(fnameescape(v:this_session))
+  endif
+endfunction
+
+function! s:cleanhome()
+  if filereadable("Startify")
+    silent ! rm Startify
   endif
 endfunction
 


### PR DESCRIPTION
Sometimes you can accidentally press ZZ or :wq and save Startify buffer into file. Function checks before quit if Startify file exists, and delete it if so.
Also file is readonly.