### PR TITLE
Make jump to a bookmarked directory correctly

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -807,7 +807,7 @@ function! s:check_user_options(path) abort
   elseif get(g:, 'startify_change_to_vcs_root')
     call s:cd_to_vcs_root(a:path)
   elseif get(g:, 'startify_change_to_dir', 1)
-    execute 'lcd' isdirectory(a:path) ? a:path : fnamemodify(a:path, ':h')
+    execute 'lcd' isdirectory(expand(a:path)) ? a:path : fnamemodify(a:path, ':h')
   endif
 endfunction
 


### PR DESCRIPTION
When specifying a directory path including environment valiables from bookmark, vim-startify executed `lcd` command passing its parent directory instead of the specified directory as the argument.
It was caused because `isdirecotry()` can not expand environment variables.
This fix simply adds `expand()` to the argument of `isdirectory()` when changing current directory.