### PR TITLE
put trailing separator to fix incorrect current dir listing

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -559,7 +559,7 @@ endfun
 
 " Function: s:show_dir {{{1
 function! s:show_dir() abort
-  return s:display_by_path(getcwd(), ':.', 0)
+  return s:display_by_path(getcwd() . s:sep, ':.', 0)
 endfunction
 
 " Function: s:show_files {{{1


### PR DESCRIPTION
This was the quickest fix I could think of.. Basically, if I was in `somedir`, it would also match with any other directories that start with `somedir` from `v:oldfiles` for recents files edited from current directory. I guess this is a fair enough fix. If not, a better fix would be awesome.

```
core
└── a.py
core-api
└── b.py
```

If you have `core-api/b.py` on `v:undofiles` and if you open vim on `core`, its gonna list the `core-api/b.py` as well assuming core and core-api are sub-directory in same directory.