### PR TITLE
[RFC] Make entry format customizable

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -456,12 +456,11 @@ function! s:display_by_path(path_prefix, path_format, use_env) abort
   let oldfiles = call(get(g:, 'startify_enable_unsafe') ? 's:filter_oldfiles_unsafe' : 's:filter_oldfiles',
         \ [a:path_prefix, a:path_format, a:use_env])
 
-  let entry_format = "s:padding_left .'['. index .']'. repeat(' ', (3 - strlen(index)))"
-  if exists('*WebDevIconsGetFileTypeSymbol') && get(g:, 'webdevicons_enable')
-    " support for vim-devicons
-    let entry_format .= ". WebDevIconsGetFileTypeSymbol(entry_path) .' '.  entry_path"
+  let entry_format = "s:padding_left .'['. index .']'. repeat(' ', (3 - strlen(index))) ."
+  if exists('*StartifyEntryFormat')
+    let entry_format .= StartifyEntryFormat()
   else
-    let entry_format .= '. entry_path'
+    let entry_format .= 'entry_path'
   endif
 
   if !empty(oldfiles)

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -30,6 +30,7 @@ CONTENTS                                                     *startify-contents*
     COMMANDS ....................................... |startify-commands|
     MAPPINGS ....................................... |startify-mappings|
     COLORS ......................................... |startify-colors|
+    MISC ........................................... |startify-misc|
     FAQ ............................................ |startify-faq|
     EXAMPLE ........................................ |startify-example|
 
@@ -766,6 +767,26 @@ Example: (my terminal emulator supports 256 colors)
     highlight StartifyPath    ctermfg=245
     highlight StartifySlash   ctermfg=240
     highlight StartifySpecial ctermfg=240
+<
+==============================================================================
+MISC                                                             *startify-misc*
+
+Changing the entry format:~
+
+You can create a function `StartifyEntryFormat()` which returns a string that
+gets evaluated in Startify. In that string, `entry_path` and `absolute_path`
+will be replaced by their respective values.
+
+`absolute_path` is self-explaining and `entry_path` is the same path but
+potentially shortened, depending on options like |g:startify_relative_path|.
+
+So, let us assume there is a function `GetLogo(path)` that returns a unicode
+logo depending on the filetype of a given file. Then you could prepend the
+logo to each Startify entry by putting this in your vimrc:
+>
+    function! StartifyEntryFormat()
+        return 'GetLogo(absolute_path) ." ". entry_path'
+    endfunction
 <
 ==============================================================================
 FAQ                                                               *startify-faq*


### PR DESCRIPTION
@wsdjeg

So, using this PR you can define a function called `startify#entry_format()`. It has to return a string which will get _evaluated in a VimL context_.

You can use any VimL expressions in that string. There's also:

- `absolute_format`: Well, it's the absolute path for this entry.
- `entry_format`: Will be replaced by the entry that Startify would use usually. This can be normalized and is not supposed to be used with other functions.

Example:

```vim
function! What(path)
  return filereadable(a:path)
endfunction

function! startify#entry_format()
  return 'What(absolute_path) ." ". entry_path'
endfunction
```