### PR TITLE
Avoid taking over a modified buffer

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -47,6 +47,10 @@ function! startify#insane_in_the_membrane() abort
     return
   endif
 
+  if &modified
+    return
+  endif
+
   if !empty(v:servername) && exists('g:startify_skiplist_server')
     for servname in g:startify_skiplist_server
       if servname == v:servername


### PR DESCRIPTION
Hi @mhinz!  Great job with vim-startify.  I did find a bug, though...

Let's say the current buffer has unsaved changes, and I invoke `:Startify`.  The first thing that happens is `:enew`, which asks `Save changes to "..."? [Y]es, (N)o, (C)ancel:`.  But if I _cancel_, `startify#insane_in_the_membrane()` ends up blowing away the modified buffer and my valuable unsaved changes.

Luckily, this was trivial to fix.  I hope you incorporate my patch.