### PR TITLE
Set buftype=nofile

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -151,7 +151,7 @@ function! startify#insane_in_the_membrane() abort
 
   silent! %foldopen!
   silent! file Startify
-  set filetype=startify readonly
+  set filetype=startify readonly buftype=nofile
 
   if exists('##DirChanged')
     autocmd startify DirChanged <buffer> Startify

--- a/test/feature/buffer.vader
+++ b/test/feature/buffer.vader
@@ -5,7 +5,7 @@ Before:
 Execute (Check buffer options):
   AssertEqual 'startify', &filetype
   AssertEqual 'wipe',     &bufhidden
-  AssertEqual '',         &buftype
+  AssertEqual 'nofile',   &buftype
   AssertEqual 0,          &buflisted
   AssertEqual 0,          &cursorcolumn
   AssertEqual 0,          &cursorline


### PR DESCRIPTION
The buftype option determines, if Vim considers a buffer to be an actual
file or not and since the startify buffer does not really relate to any
actual file, it makes sense to also set the 'buftype' option to be
"nofile".

In addition, this fixes the bug that vim-airline considers the current
buffer to be '[noperm]', since it is

`&readonly && !filereadable(bufname('%'))`
![grafik](https://user-images.githubusercontent.com/244927/39914834-83497b54-5506-11e8-93eb-5e3d1d75fd6f.png)


Also change the corresponding Vader test.