### PR TITLE
fix: unlet s:last_message with no error in show_list

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -468,7 +468,7 @@ function! s:show_lists(lists) abort
         continue
       endtry
       if empty(entries)
-        unlet s:last_message
+        unlet! s:last_message
         continue
       endif
 


### PR DESCRIPTION
If entries is empty, it will try to unlet of non-existing
variable and throw the erorr.
Fixes #328