### PR TITLE
Do not add a blank line to header when one exists

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -514,7 +514,7 @@ endfunction
 " Function: s:set_custom_section {{{1
 function! s:set_custom_section(section) abort
   if type(a:section) == type([])
-    return a:section
+    return copy(a:section)
   elseif type(a:section) == type('')
     return empty(a:section) ? [] : eval(a:section)
   endif


### PR DESCRIPTION
This prevents the space below the header from growing when Starify is used more than once in a session.

I quickly made this PR because I use Starify many times a session, and the space below the header would grow endlessly.  I haven't written any tests for it, but I'd be happy to if you could tell me how.

Thanks for reading my PR.