### PR TITLE
Evaluate savevars early

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -263,6 +263,11 @@ endfunction
 
 " Function: #session_write {{{1
 function! startify#session_write(spath)
+  " preserve existing variables from savevars
+  if exists('g:startify_session_savevars')
+    let savevars = map(filter(copy(g:startify_session_savevars), 'exists(v:val)'), '"let ". v:val ." = ". strtrans(string(eval(v:val)))')
+  endif
+
   " if this function is called while being in the Startify buffer
   " (by loading another session or running :SSave/:SLoad directly)
   " switch back to the previous buffer before saving the session
@@ -308,9 +313,9 @@ function! startify#session_write(spath)
       endfor
     endif
 
-    " put existing variables from savevars into session file
-    if exists('g:startify_session_savevars')
-      call append(line('$')-3, map(filter(copy(g:startify_session_savevars), 'exists(v:val)'), '"let ". v:val ." = ". strtrans(string(eval(v:val)))'))
+    " put variables from savevars into session file
+    if !empty(savevars)
+      call append(line('$')-3, savevars)
     endif
 
     " put commands from savecmds into session file


### PR DESCRIPTION
In `g:startify_session_savevars` I have a variable that contains the actual layout of all windows, but the value written in session file always contained an extra window what I didn't expect (that window had the session file opened).

The problem is that `split` triggers BufWinEnter/Leave auto commands that I use to update my variable:

https://github.com/mhinz/vim-startify/blob/53c8799ad035ce1649d4bc6ab6cd4297d304a374/autoload/startify.vim#L302

This PR tries to evaluate savevars as early as possible.