### PR TITLE
Make Neovim to use the XDG data directory

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -14,7 +14,8 @@ let s:numfiles       = get(g:, 'startify_files_number', 10)
 let s:show_special   = get(g:, 'startify_enable_special', 1)
 let s:relative_path  = get(g:, 'startify_relative_path') ? ':~:.' : ':p:~'
 let s:session_dir    = resolve(expand(get(g:, 'startify_session_dir',
-      \ has('win32') ? '$HOME\vimfiles\session' : '~/.vim/session')))
+      \ has('win32') ? '$HOME\vimfiles\session' :
+      \ has('nvim') ? stdpath('data') . '/session' : '~/.vim/session')))
 let s:tf             = exists('g:startify_transformations')
 
 let s:skiplist = get(g:, 'startify_skiplist', [

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -134,7 +134,8 @@ default values.
 <
 The directory to save/load sessions to/from.
 
-The default for Windows systems is '$HOME\vimfiles\session'.
+The default for Windows systems is '$HOME\vimfiles\session'. The
+default for Neovim is '$XDG_DATA_HOME/nvim/session'.
 
 ------------------------------------------------------------------------------
                                                          *g:startify_list_order*


### PR DESCRIPTION
This is to avoid the creation of the `.vim` directory by mistake. I am not sure if the way I used the ternary operator is The Right Thing To Do™ but I wanted to change as little code as possible.