### PR TITLE
Introduce batchmode

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -844,8 +844,8 @@ endfunction
 
 " Function: #set_batchmode {{{1
 function! startify#set_batchmode(batchmode) abort
-  let s:batchmode = a:batchmode
-  echomsg 'Batchmode: '. s:batchmode
+  let s:batchmode = (a:batchmode == s:batchmode) ? '' : a:batchmode
+  echo empty(s:batchmode) ? 'Batchmode off' : 'Batchmode: '. s:batchmode
 endfunction
 
 " Function: s:set_mark {{{1

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -46,30 +46,37 @@ USAGE                                                           *startify-usage*
 Startify basically provides two things:
 
 1) If you start Vim without giving any filenames to it (or pipe stuff to it so
-   it reads from STDIN), startify will show a small but pretty start screen
-   that shows recently used files (using viminfo) and sessions by default.
+   it reads from STDIN), startify will show a pretty start screen that shows
+   recently used files (using viminfo/shada) and sessions by default.
 
    Additionally, you can define bookmarks (thus entries for files) and
    commands that always should be available on the start screen.
 
-   You can either navigate to a certain menu entry and hit enter or you just
-   key in whatever is written between the square brackets on that line. You
-   can even double-click anywhere on the line now.
+   You can either navigate to a certain menu entry and hit `<cr>` or just
+   enter the index (the index is whatever is written between the square
+   brackets on that line). You can even double-click anywhere on the line.
 
-   In addition, 'e' creates an empty buffer, 'i' creates an empty buffer and
-   jumps into insert mode, 'q' quits either the buffer or, if there is no
+   In addition, `e` creates an empty buffer, `i` creates an empty buffer and
+   jumps into insert mode, `q` quits either the buffer or, if there is no
    other listed buffer left, Vim itself.
 
-   Moreover, you can open several files at one go. Navigate to an entry and
-   hit either 'b' (open in same window), 's' (open in split), 'v' (open in
-   vertical split) or 't' (open in tab). You can do that for multiple entries.
+   Moreover, you can open multiple buffers at once. Navigate to an entry and
+   hit either `b` (open in same window), `s` (open in split), `v` (open in
+   vertical split) or `t` (open in tab). You can do that for multiple entries.
    You can also mix them. The order of the selections will be remembered.
-   Afterwards execute these actions via <cr>.
+   Afterwards execute these actions via `<cr>`.
+
+   The uppercase variants of b/s/v/t enable the batchmode which lets you
+   select any entries without navigating there first. Every following index
+   will be opened in the currently active mode. E.g. to open the buffers with
+   the indices 0, 2, and 4, use `B024` instead of `bjjbjjb`. To disable
+   batchmode, just use the same uppercase key again, or any of the lowercase
+   variants.
 
    When the selection is finished, Startify will close automatically. You can
    reopen the screen via :Startify.
 
-   And you can define your own custom ascii art header now!
+   And you can define your own custom ascii art header!
 
 2) The plugin eases the handling of loading and saving sessions by putting
    sessions in a central directory.


### PR DESCRIPTION
In batchmode you can mark entries without going to their line first.

Use uppercase characters `B`/`S`/`V`/`T` to switch between modes.

E.g. V123 is the same as going to entry 1, hitting <kbd>v</kbd>, then entry 2, hitting <kbd>v</kbd>, then entry 3, hitting <kbd>v</kbd>. Use `<cr>` as usual to open the marked entries.

Using the lowercase variants still works as before and resets an active batchmode.

Implements https://github.com/mhinz/vim-startify/issues/357

---

CC @hupfdule