### PR TITLE
Add 'browser' list type.

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -19,6 +19,11 @@ function! startify#get_separator() abort
   return !exists('+shellslash') || &shellslash ? '/' : '\'
 endfunction
 
+" Function: set_browserdepth {{{1
+function! s:set_browserdepth(path) abort
+  let b:startify.browserdepth = (a:path == "" || s:endswithsep(a:path)) ? a:path : a:path . s:sep
+endfunction
+
 " Function: #insane_in_the_membrane {{{1
 function! startify#insane_in_the_membrane(on_vimenter) abort
   " Handle vim -y, vim -M.
@@ -38,6 +43,8 @@ function! startify#insane_in_the_membrane(on_vimenter) abort
       endif
     endfor
   endif
+
+  let oldsettings = get(b:, "startify", {})
 
   if line2byte('$') != -1
     noautocmd enew
@@ -71,6 +78,13 @@ function! startify#insane_in_the_membrane(on_vimenter) abort
   call append('$', g:startify_header)
 
   let b:startify = { 'tick': 0, 'entries': {}, 'indices': [] }
+  let b:startify.cwd = getcwd()
+
+  if oldsettings == {}
+    call s:set_browserdepth("")
+  else
+    call s:set_browserdepth(get(oldsettings, 'browserdepth', ""))
+  endif
 
   if s:show_special
     call append('$', [s:padding_left .'[e]  <empty buffer>', ''])
@@ -126,7 +140,13 @@ function! startify#insane_in_the_membrane(on_vimenter) abort
   setlocal nomodifiable nomodified
 
   call s:set_mappings()
-  call cursor(b:startify.firstline, 5)
+
+  if get(g:, 'startify_browser_startup_jump', 0) || !get(g:, 'startify_prevent_browser_cursor_lock', 0) && get(oldsettings, 'jumptobrowser', 0)
+    call cursor(b:startify.browserline, 5)
+  else
+    call cursor(b:startify.firstline, 5)
+  endif
+
   autocmd startify CursorMoved <buffer> call s:set_cursor()
 
   silent! %foldopen!
@@ -403,6 +423,15 @@ function! startify#open_buffers(...) abort
   endif
 endfunction
 
+" Function: #toggle_show_dotfiles {{{1
+function! startify#toggle_show_dotfiles() abort
+  if get(g:, 'startify_show_dotfiles') == 1
+    let g:startify_show_dotfiles = 0
+  else
+    let g:startify_show_dotfiles = 1
+  endif
+endfunction
+
 " Function: s:get_lists {{{1
 function! s:get_lists() abort
   if exists('g:startify_lists')
@@ -487,6 +516,10 @@ function! s:open_buffer(entry)
     execute a:entry.cmd
   elseif a:entry.type == 'session'
     execute a:entry.cmd a:entry.path
+  elseif a:entry.type == 'dir'
+    call s:set_browserdepth(a:entry.path)
+    let b:startify.jumptobrowser = 1
+    call startify#insane_in_the_membrane(0)
   elseif a:entry.type == 'file'
     if line2byte('$') == -1
       execute 'edit' a:entry.path
@@ -514,10 +547,7 @@ function! s:set_custom_section(section) abort
 endfunction
 
 " Function: s:display_by_path {{{1
-function! s:display_by_path(path_prefix, path_format, use_env) abort
-  let oldfiles = call(get(g:, 'startify_enable_unsafe') ? 's:filter_oldfiles_unsafe' : 's:filter_oldfiles',
-        \ [a:path_prefix, a:path_format, a:use_env])
-
+function! s:display_by_path(entries) abort
   let entry_format = "s:padding_left .'['. index .']'. repeat(' ', (3 - strlen(index))) ."
   if exists('*StartifyEntryFormat')
     let entry_format .= StartifyEntryFormat()
@@ -525,18 +555,18 @@ function! s:display_by_path(path_prefix, path_format, use_env) abort
     let entry_format .= 'entry_path'
   endif
 
-  if !empty(oldfiles)
+  if !empty(a:entries)
     if exists('s:last_message')
       call s:print_section_header()
     endif
 
-    for [absolute_path, entry_path] in oldfiles
+    for [type, absolute_path, entry_path] in a:entries
       let index = s:get_index_as_string()
       call append('$', eval(entry_format))
       if has('win32')
         let absolute_path = substitute(absolute_path, '\[', '\[[]', 'g')
       endif
-      call s:register(line('$'), index, 'file', 'edit', absolute_path)
+      call s:register(line('$'), index, type, 'edit', absolute_path)
     endfor
 
     call append('$', '')
@@ -579,7 +609,7 @@ function! s:filter_oldfiles(path_prefix, path_format, use_env) abort
 
     let entries[absolute_path]  = 1
     let counter                -= 1
-    let oldfiles += [[fnameescape(absolute_path), entry_path]]
+    let oldfiles += [['file', fnameescape(absolute_path), entry_path]]
   endfor
 
   if a:use_env
@@ -628,7 +658,7 @@ function! s:filter_oldfiles_unsafe(path_prefix, path_format, use_env) abort
     let entry_path              = fnamemodify(absolute_path, a:path_format)
     let entries[absolute_path]  = 1
     let counter                -= 1
-    let oldfiles               += [[fnameescape(absolute_path), entry_path]]
+    let oldfiles               += [['file', fnameescape(absolute_path), entry_path]]
   endfor
 
   return oldfiles
@@ -636,12 +666,90 @@ endfunction
 
 " Function: s:show_dir {{{1
 function! s:show_dir() abort
-  return s:display_by_path(getcwd() . s:sep, ':.', 0)
+  let oldfiles = call(get(g:, 'startify_enable_unsafe') ? 's:filter_oldfiles_unsafe' : 's:filter_oldfiles',
+        \ [getcwd() . s:sep, ':.', 0])
+  return s:display_by_path(oldfiles)
+endfunction
+
+" Function: s:show_browser {{{1
+function! s:show_browser() abort
+  let cwd = get(get(b:, 'startify', {}), 'cwd')
+  let browserdepth = get(get(b:, 'startify', {}), 'browserdepth')
+
+  let files = []
+  let currentdir = browserdepth == "" ? [] : split(glob(browserdepth . '..'), '\n')
+  let currentdir += split(glob(browserdepth . '*'), '\n')
+
+  if get(g:, 'startify_show_dotfiles')
+    let currentdir += filter(split(glob(browserdepth . '.*'), '\n'), 'v:val != "' . browserdepth . '." && v:val != "' . browserdepth . '.."')
+  endif
+
+  call sort(currentdir, 'i')
+
+  for file in currentdir
+    let isdir = isdirectory(file)
+    let entry_path = isdir ? file . s:sep : file
+    let entry_path = strpart(entry_path, strlen(browserdepth), strlen(entry_path))
+
+    if isdir
+      let browserdepth_path = (entry_path == "../") ? s:striplastdirsegment(browserdepth) : browserdepth . entry_path
+      let files += [['dir', browserdepth_path, entry_path]]
+    else
+      let absolute_path = cwd . s:sep . file
+      let files += [['file', absolute_path, entry_path]]
+    endif
+  endfor
+
+  function! s:sort_by_dot(foo, bar)
+    let foo = strpart(a:foo[2], 0, 1)
+    let bar = strpart(a:bar[2], 0, 1)
+    return foo == bar ? 0 : (bar == '.' ? 1 : -1)
+  endfunction
+
+  function! s:sort_by_directory(foo, bar)
+    let foo = strpart(a:foo[2], strlen(a:foo[2])-1, 1)
+    let bar = strpart(a:bar[2], strlen(a:bar[2])-1, 1)
+    return foo == bar ? 0 : (bar == '/' ? 1 : -1)
+  endfunction
+
+  call sort(files, 's:sort_by_dot')
+  call sort(files, 's:sort_by_directory')
+
+  let s:last_message = ['   ' . s:stripendingsep(cwd . s:sep . browserdepth)]
+  let result = s:display_by_path(files)
+
+  if !get(get(b:, 'startify', {}), 'browserline', 0)
+    let b:startify.browserline = line('$') - len(files)
+  endif
+
+  return result
+endfunction
+
+" Function s:endswithsep {{{1
+function! s:endswithsep(path) abort
+  return strpart(a:path, strlen(a:path)-1, 1) == s:sep
+endfunction
+
+" Function s:stripendingsep {{{1
+function! s:stripendingsep(path) abort
+  if !s:endswithsep(a:path)
+    return a:path
+  endif
+
+  return strpart(a:path, 0, strlen(a:path)-1)
+endfunction
+
+" Function: s:striplastdirsegment {{{1
+function! s:striplastdirsegment(path) abort
+  let fullpath = s:stripendingsep(a:path)
+  return strpart(fullpath, 0, strridx(fullpath, s:sep))
 endfunction
 
 " Function: s:show_files {{{1
 function! s:show_files() abort
-  return s:display_by_path('', s:relative_path, get(g:, 'startify_use_env'))
+  let oldfiles = call(get(g:, 'startify_enable_unsafe') ? 's:filter_oldfiles_unsafe' : 's:filter_oldfiles',
+        \ ['', s:relative_path, get(g:, 'startify_use_env')])
+  return s:display_by_path(oldfiles)
 endfunction
 
 " Function: s:show_sessions {{{1
@@ -819,6 +927,7 @@ function! s:set_mappings() abort
   nnoremap <buffer><nowait><silent> <LeftMouse>   :call <sid>leftmouse()<cr>
   nnoremap <buffer><nowait><silent> <2-LeftMouse> :call startify#open_buffers()<cr>
   nnoremap <buffer><nowait><silent> <MiddleMouse> :enew <bar> execute 'normal! "'.(v:register=='"'?'*':v:register).'gp'<cr>
+  nnoremap <buffer><nowait><silent> .             :call startify#toggle_show_dotfiles()<cr>:Startify<cr>
 
   " Without these mappings n/N wouldn't work properly, since autocmds always
   " force the cursor back on the index.

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -158,6 +158,7 @@ This option is DEPRECATED in favor of |g:startify_lists|.
     let g:startify_lists = [
           \ { 'type': 'files',     'header': ['   MRU']            },
           \ { 'type': 'dir',       'header': ['   MRU '. getcwd()] },
+          \ { 'type': 'browser',                                   },
           \ { 'type': 'sessions',  'header': ['   Sessions']       },
           \ { 'type': 'bookmarks', 'header': ['   Bookmarks']      },
           \ { 'type': 'commands',  'header': ['   Commands']       },
@@ -186,6 +187,15 @@ Built-in types:~
 
     This lists the files from the current directory sorted by modification
     time. The number of files is limited by |g:startify_files_number|.
+
+'browser'
+
+    This serves as a browser for current directory. It lists all files and
+    directories from the current directory sorted by type (directories first)
+    and name. If the user chooses a directory, the list will switch one level
+    down, giving the user an option to go back (up one directory), just like
+    any file browser.
+    If |g:startify_show_dotfiles| is set to 1, it also shows the dot files.
 
 'bookmarks'
 
@@ -292,6 +302,31 @@ NOTE: Avoid using keys from |startify-mappings| if providing custom indices.
     let g:startify_files_number = 10
 <
 The number of files to list.
+
+------------------------------------------------------------------------------
+                                                      *g:startify_show_dotfiles*
+>
+    let g:startify_show_dotfiles = 1
+<
+Shows dot (hidden) files in browser list type.
+
+------------------------------------------------------------------------------
+                                        *g:startify_prevent_browser_cursor_lock*
+>
+    let g:startify_prevent_browser_cursor_lock = 1
+<
+If not set or set to 0, the browser list type will auto jump the cursor to the
+first browser entry when the user navigates down the directory. This feature
+makes navigation easier with j, k or arrows.
+If set to 1, it will not auto jump the cursor.
+
+------------------------------------------------------------------------------
+                                               *g:startify_browser_startup_jump*
+>
+    let g:startify_browser_startup_jump = 1
+<
+If set to 1, it moves the cursor to the first line of the browser list on
+startup.
 
 ------------------------------------------------------------------------------
                                                     *g:startify_update_oldfiles*
@@ -807,6 +842,10 @@ Open the entry with the given number.
 <
 Mark current entry to be opened in either the same window, in a split window,
 in a vertical split window or in a new tab.
+>
+    .
+<
+Toggle |g:startify_show_dotfiles| option.
 >
     <cr>
 <


### PR DESCRIPTION
This adds a `browser` list type which lists all files and directories from current location.
Allows the user to quickly navigate to a file/directory within current directory and below.
If the user selects a directory, the contents are displayed. The user can also navigate back from the deeper levels up to the current working directory.