### PR TITLE
Place custom header on first line

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -84,10 +84,14 @@ function! startify#insane_in_the_membrane(on_vimenter) abort
   let g:startify_header = exists('g:startify_custom_header')
         \ ? s:set_custom_section(g:startify_custom_header)
         \ : (exists('*strwidth') ? startify#fortune#cowsay() : [])
-  if !empty(g:startify_header)
+  if !empty(g:startify_header) && !exists('g:startify_custom_header')
     let g:startify_header += ['']  " add blank line
   endif
-  call append('$', g:startify_header)
+  if !exists('g:startify_custom_header')
+    call append('$', g:startify_header)
+  else
+    call append(0, g:startify_header)
+  endif
 
   let b:startify = { 'tick': 0, 'entries': {}, 'indices': [] }
 


### PR DESCRIPTION
Startify appends to the current buffer using `'$'` causing the first line to be left blank. This can be fixed by having the first `append()` start at `0`. However, this causes the default header to have no gap line at the top and also causes custom headers to have an extra gap line after them. To fix this, the changes are made only if there is a custom header, otherwise the behavior is the same as before.