### PR TITLE
New option: g:startify_change_cmd

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -953,11 +953,11 @@ function! s:check_user_options(path) abort
 
   if get(g:, 'startify_change_to_dir', 1)
     if isdirectory(a:path)
-      execute 'lcd' a:path
+      execute s:cd_cmd() a:path
     else
       let dir = fnamemodify(a:path, ':h')
       if isdirectory(dir)
-        execute 'lcd' dir
+        execute s:cd_cmd() dir
       else
         " Do nothing. E.g. a:path == `scp://foo/bar`
       endif
@@ -971,11 +971,21 @@ function! s:cd_to_vcs_root(path) abort
   for vcs in [ '.git', '.hg', '.bzr', '.svn' ]
     let root = finddir(vcs, dir .';')
     if !empty(root)
-      execute 'lcd' fnameescape(fnamemodify(root, ':h'))
+      execute s:cd_cmd() fnameescape(fnamemodify(root, ':h'))
       return 1
     endif
   endfor
   return 0
+endfunction
+
+" Function: s:cd_cmd {{{1
+function! s:cd_cmd() abort
+  let g:startify_change_cmd = get(g:, 'startify_change_cmd', 'lcd')
+  if g:startify_change_cmd !~# '^[lt]\?cd$'
+    call s:warn('Invalid value for g:startify_change_cmd. Defaulting to :lcd')
+    let g:startify_change_cmd = 'lcd'
+  endif
+  return g:startify_change_cmd
 endfunction
 
 " Function: s:close {{{1

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -101,6 +101,7 @@ default values.
     |g:startify_bookmarks|
     |g:startify_change_to_dir|
     |g:startify_change_to_vcs_root|
+    |g:startify_change_cmd|
     |g:startify_custom_header|
     |g:startify_enable_special|
     |g:startify_list_order|
@@ -377,6 +378,19 @@ When opening a file or bookmark, seek and change to the root directory of the
 VCS (if there is one).
 
 At the moment only git, hg, bzr and svn are supported.
+
+------------------------------------------------------------------------------
+                                                         *g:startify_change_cmd*
+>
+    let g:startify_change_cmd = 'lcd'
+<
+The default command for switching directories. Valid values:
+
+    'cd'  (|:cd|)
+    'lcd' (|:lcd|)
+    'tcd' (|:tcd|)
+
+Affects |g:startify_change_to_dir| and |g:startify_change_to_vcs_root|.
 
 ------------------------------------------------------------------------------
                                                            *g:startify_skiplist*


### PR DESCRIPTION
Different people prefer different values. Can be set to 'cd', 'lcd', or 'tcd'.

Closes https://github.com/mhinz/vim-startify/issues/425