### PR TITLE
Changed startify#center to use winwidth(0) instead of &columns

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -440,7 +440,7 @@ endfunction
 function! startify#center(lines) abort
   let longest_line = max(map(copy(a:lines), 'strwidth(v:val)'))
   return map(copy(a:lines),
-        \ 'repeat(" ", (&columns / 2) - (longest_line / 2) - 1) . v:val')
+        \ 'repeat(" ", (winwidth(0) / 2) - (longest_line / 2) - 1) . v:val')
 endfunction
 
 " Function: s:get_lists {{{1


### PR DESCRIPTION
This change would be useful when updating the centering in a split for example ([issue](https://github.com/mhinz/vim-startify/issues/458))