### PR TITLE
feat: use g:startify_custom_header_center for centering the header

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -84,9 +84,15 @@ function! startify#insane_in_the_membrane(on_vimenter) abort
   endif
 
   " Must be global so that it can be read by syntax/startify.vim.
-  let g:startify_header = exists('g:startify_custom_header')
-        \ ? s:set_custom_section(g:startify_custom_header)
-        \ : (exists('*strwidth') ? startify#pad(startify#fortune#cowsay()) : [])
+  if get(g:, 'startify_custom_header_center', 0)
+    let g:startify_header = exists('g:startify_custom_header')
+          \ ? s:set_custom_section(startify#center(g:startify_custom_header))
+          \ : (exists('*strwidth') ? startify#pad(startify#fortune#cowsay()) : [])
+  else
+    let g:startify_header = exists('g:startify_custom_header')
+          \ ? s:set_custom_section(g:startify_custom_header)
+          \ : (exists('*strwidth') ? startify#pad(startify#fortune#cowsay()) : [])
+  endif
   if !empty(g:startify_header)
     let g:startify_header += ['']  " add blank line
   endif

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -596,6 +596,15 @@ NOTE: There is no sanitizing going on, so you should know what you're doing!
       Avoid using keys from |startify-mappings|.
 
 ------------------------------------------------------------------------------
+                                                      *g:startify_custom_header_center*
+This option allows centering the custom header by setting:
+>
+    let g:startify_custom_header_center = 1
+<
+It will be undefined until the user sets it, and the custom header will not be
+centered unless it is set to be true.
+
+------------------------------------------------------------------------------
                                                       *g:startify_custom_header*
 >
     let g:startify_custom_header = 'startify#pad(startify#fortune#cowsay())'

--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -20,6 +20,7 @@ augroup startify
   autocmd VimLeavePre * nested call s:on_vimleavepre()
   autocmd QuickFixCmdPre  *vimgrep* let g:startify_locked = 1
   autocmd QuickFixCmdPost *vimgrep* let g:startify_locked = 0
+  autocmd VimResized * if &filetype ==# 'startify' | call startify#insane_in_the_membrane(0) | endif
 augroup END
 
 function! s:update_oldfiles(file)


### PR DESCRIPTION
This commit adds an option `g:startify_custom_header_center` to center the custom header, but it will not be defined unless the user sets it. The problem with `startify#center(...)` is that the centered custom header will not be centered on redraw (i.e. calling `startify#insane_in_the_membrane(0)`. It is similar to glepnir/dashboard-nvim#52.