### PR TITLE
default the value of g:startify_change_to_dir to the value of autochdir

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -953,7 +953,7 @@ function! s:check_user_options(path) abort
     return
   endif
 
-  if get(g:, 'startify_change_to_dir', 1)
+  if get(g:, 'startify_change_to_dir', &autochdir)
     if isdirectory(a:path)
       execute s:cd_cmd() a:path
     else


### PR DESCRIPTION
It doesn't really make sense for the `g:startify_change_to_dir` setting to even exist since it does the same thing as `autochdir` but for backwards compatibility's sake, instead of removing it, let's just default it to the value of the user's `autochdir` setting.

Fixes #472 