### PR TITLE
Allow autoloading sessions from the session directory

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -948,13 +948,22 @@ endfunction
 
 " Function: s:check_user_options {{{1
 function! s:check_user_options(path) abort
-  let session = a:path . s:sep .'Session.vim'
+  if get(g:, 'startify_session_autoload')
+    let session = a:path . s:sep . 'Session.vim'
+    if filereadable(glob(session))
+      execute 'silent bwipeout' a:path
+      call startify#session_delete_buffers()
+      execute 'source' session
+      return
+    endif
 
-  if get(g:, 'startify_session_autoload') && filereadable(glob(session))
-    execute 'silent bwipeout' a:path
-    call startify#session_delete_buffers()
-    execute 'source' session
-    return
+    let session = startify#get_session_path() . startify#get_separator() . fnamemodify(getcwd(), ':t')
+    if filereadable(glob(session))
+      execute 'silent bwipeout' a:path
+      call startify#session_delete_buffers()
+      execute 'source' session
+      return
+    endif
   endif
 
   if get(g:, 'startify_change_to_vcs_root') && s:cd_to_vcs_root(a:path)

--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -35,8 +35,13 @@ endfunction
 
 function! s:on_vimenter()
   if !argc() && line2byte('$') == -1
-    if get(g:, 'startify_session_autoload') && filereadable('Session.vim')
-      source Session.vim
+    if get(g:, 'startify_session_autoload')
+      let session = startify#get_session_path() . startify#get_separator() . fnamemodify(getcwd(), ':t')
+      if filereadable('Session.vim')
+        source Session.vim
+      elseif filereadable(session)
+        execute 'source ' . session
+      endif
     elseif !get(g:, 'startify_disable_at_vimenter')
       call startify#insane_in_the_membrane(1)
     endif


### PR DESCRIPTION
At the moment we only support autoloading session from the current
directory with a Session.vim file. This change will allow Startify to
autoload a session if the current directory matches the name of a saved
session in the global session directory.