### PR TITLE
New option: g:startify_fortune_box_max_width

### DIFF
--- a/autoload/startify/fortune.vim
+++ b/autoload/startify/fortune.vim
@@ -28,6 +28,7 @@ endfunction
 " Function: #boxed {{{1
 function! startify#fortune#boxed(...) abort
   let wrapped_quote = []
+  let box_max_width = exists('g:startify_fortune_box_max_width') ? g:startify_fortune_box_max_width : 50
   if a:0 && type(a:1) == type([])
     let quote = a:1
   else
@@ -35,7 +36,7 @@ function! startify#fortune#boxed(...) abort
     let quote = type(Quote) == type(function('tr')) ? Quote() : Quote
   endif
   for line in quote
-    let wrapped_quote += split(line, '\%50c.\{-}\zs\s', 1)
+    let wrapped_quote += split(line, '\%' . box_max_width . 'c.\{-}\zs\s', 1)
   endfor
   let wrapped_quote = s:draw_box(wrapped_quote)
   return wrapped_quote

--- a/doc/startify.txt
+++ b/doc/startify.txt
@@ -117,6 +117,7 @@ default values.
     |g:startify_disable_at_vimenter|
     |g:startify_enable_unsafe|
     |g:startify_files_number|
+    |g:startify_fortune_box_max_width|
     |g:startify_fortune_use_unicode|
     |g:startify_padding_left|
     |g:startify_relative_path|
@@ -423,6 +424,16 @@ Example:
            \ escape(fnamemodify($HOME, ':p'), '\') .'mysecret.txt',
            \ ]
 <
+------------------------------------------------------------------------------
+                                              *g:startify_fortune_box_max_width*
+>
+    let g:startify_fortune_box_max_width = 50
+<
+The maximum width of the fortune box.
+
+NOTE: To be taken into account, the value must be changed before the plugin is
+loaded.
+
 ------------------------------------------------------------------------------
                                                 *g:startify_fortune_use_unicode*
 >


### PR DESCRIPTION
Previously the fortune box maximum size was hardcoded to 50 characters. This option would allow the user to change this value. (As far as I'm concerned I needed a larger value).

Regards.