### PR TITLE
Don't process malformed file names

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -659,7 +659,14 @@ function! s:filter_oldfiles_unsafe(path_prefix, path_format, use_env) abort
       continue
     endif
 
-    let absolute_path = glob(fnamemodify(fname, ":p"))
+
+    " some plugins insert files into v:oldfiles with strange paths such as
+    " '[ Some message ]' and startify errors on attempting to handle them here.
+    try
+      let absolute_path = glob(fnamemodify(fname, ":p"))
+    catch /^Vim\%((\a\+)\)\=:E944:/
+      let absolute_path = ""
+    endtry
     if empty(absolute_path)
           \ || has_key(entries, absolute_path)
           \ || (absolute_path =~ is_dir)


### PR DESCRIPTION
I'm not sure what the cause was, but I ended up with an entry in my file
list that was just some regex pattern. So the processing in this loop
was crashing at the `glob` below. Fix this by ignoring non-existant
files.
