### PR TITLE
Added command SPrev to load previous session

### DIFF
--- a/plugin/startify.vim
+++ b/plugin/startify.vim
@@ -60,6 +60,7 @@ endfunction
 command! -nargs=? -bar -bang -complete=customlist,startify#session_list SLoad   call startify#session_load(<bang>0, <f-args>)
 command! -nargs=? -bar -bang -complete=customlist,startify#session_list SSave   call startify#session_save(<bang>0, <f-args>)
 command! -nargs=? -bar -bang -complete=customlist,startify#session_list SDelete call startify#session_delete(<bang>0, <f-args>)
+command! -nargs=0 -bar SPrev call startify#session_load_previous()
 command! -nargs=0 -bar SClose call startify#session_close()
 command! -nargs=0 -bar Startify call startify#insane_in_the_membrane(0)
 command! -nargs=0 -bar StartifyDebug call startify#debug()


### PR DESCRIPTION
For easier session switching.
Additionally to __LAST__ also a __PREV__ will be created.
A command SPrev is added and will load __PREV__.
It also switches __LAST__ and __PREV__, so that continues SPrev is possible.

A small bug is fixed where SLoad! loads __LAST__ and the session name is then __LAST__ instead of the name __LAST__ points to. Now instead of loading __LAST__ first the session name it points to is acquired and then this session is loaded.